### PR TITLE
Fix proxy opt-out (#2), Windows startup crashes (#3, #4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,22 @@
 # ====================================
 
 # Anthropic API Key (required for AI Agent)
+# By default this key is sent DIRECTLY to https://api.anthropic.com and nowhere else.
 ANTHROPIC_API_KEY=sk-ant-...
 
 # Backend server port
 PORT=5001
+
+# Optional: Claude API proxy / relay.
+# Leave USE_CLAUDE_PROXY unset or "false" to talk to Anthropic directly.
+# Set it to "true" ONLY if you intentionally want every request (and the
+# CLAUDE_PROXY_API_KEY below) routed through a third-party relay. When the
+# proxy is disabled, CLAUDE_PROXY_BASE_URL is ignored and your
+# ANTHROPIC_API_KEY is never sent to the proxy.
+# USE_CLAUDE_PROXY=false
+# CLAUDE_PROXY_API_KEY=
+# CLAUDE_PROXY_BASE_URL=https://api.anthropic.com
+# CLAUDE_PROXY_MODEL=claude-3-5-sonnet-20241022
 
 # ====================================
 # Frontend Configuration

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,10 +1,24 @@
 # Perfect Web Clone Backend Configuration
 
 # Anthropic API Key (required)
+# By default this key is sent DIRECTLY to https://api.anthropic.com and nowhere else.
 ANTHROPIC_API_KEY=sk-ant-...
 
 # Server port
 PORT=5001
+
+# ====================================
+# Optional: Claude API proxy / relay
+# ====================================
+# Leave USE_CLAUDE_PROXY unset or "false" to talk to Anthropic directly.
+# Set it to "true" ONLY if you intentionally want every request (and the
+# CLAUDE_PROXY_API_KEY below) routed through a third-party relay. When the
+# proxy is disabled, CLAUDE_PROXY_BASE_URL is ignored and your
+# ANTHROPIC_API_KEY is never sent to the proxy.
+# USE_CLAUDE_PROXY=false
+# CLAUDE_PROXY_API_KEY=
+# CLAUDE_PROXY_BASE_URL=https://api.anthropic.com
+# CLAUDE_PROXY_MODEL=claude-3-5-sonnet-20241022
 
 # OpenAI API Key (optional, for GPT-4 fallback)
 # OPENAI_API_KEY=sk-...

--- a/backend/agent/core/conversation_pipeline.py
+++ b/backend/agent/core/conversation_pipeline.py
@@ -53,7 +53,10 @@ class ConversationPipeline:
         """
         # 从环境变量获取配置
         self.api_key = api_key or self._get_api_key()
-        self.base_url = base_url or os.getenv("CLAUDE_PROXY_BASE_URL")
+        # 仅当显式启用代理时才使用代理 URL，避免在 USE_CLAUDE_PROXY=false 时
+        # 把官方 API Key 静默转发到第三方代理。
+        use_proxy = os.getenv("USE_CLAUDE_PROXY", "").lower() == "true"
+        self.base_url = base_url or (os.getenv("CLAUDE_PROXY_BASE_URL") if use_proxy else None)
         self.default_model = default_model
         self.enable_fallback = enable_fallback
 

--- a/backend/code_gen_config.py
+++ b/backend/code_gen_config.py
@@ -12,7 +12,7 @@ load_dotenv()
 # ==================== Claude Proxy Configuration ====================
 # 中转服务配置
 
-USE_CLAUDE_PROXY = True
+USE_CLAUDE_PROXY = os.getenv("USE_CLAUDE_PROXY", "false").lower() == "true"
 CLAUDE_PROXY_API_KEY = os.getenv("CLAUDE_PROXY_API_KEY", "")
 CLAUDE_PROXY_BASE_URL = os.getenv("CLAUDE_PROXY_BASE_URL", "https://api.anthropic.com/v1/messages")
 CLAUDE_PROXY_MODEL = os.getenv("CLAUDE_PROXY_MODEL", "claude-3-5-sonnet-20241022")

--- a/backend/main.py
+++ b/backend/main.py
@@ -172,8 +172,11 @@ async def generate_project_name(request: ProjectNameRequest):
     """
     try:
         # Get API key (support both direct and proxy)
+        # Only route through the proxy when it is explicitly enabled, otherwise
+        # the direct ANTHROPIC_API_KEY must never be sent to a third-party URL.
+        use_proxy = os.getenv("USE_CLAUDE_PROXY", "").lower() == "true"
         api_key = os.getenv("ANTHROPIC_API_KEY") or os.getenv("CLAUDE_PROXY_API_KEY")
-        base_url = os.getenv("CLAUDE_PROXY_BASE_URL")
+        base_url = os.getenv("CLAUDE_PROXY_BASE_URL") if use_proxy else None
 
         if not api_key:
             logger.warning("No API key for project naming")
@@ -291,10 +294,26 @@ if __name__ == "__main__":
 
     port = int(os.getenv("PORT", "5100"))
 
+    # Windows + Python 3.13 + ProactorEventLoop + uvicorn reload is broken:
+    # the reloader's worker inherits the listening socket and
+    # CreateIoCompletionPort rejects it with WinError 87 (see issue #4).
+    # Disable auto-reload only in that exact combination.
+    reload_enabled = not (sys.platform == "win32" and sys.version_info >= (3, 13))
+    if not reload_enabled:
+        logger.warning(
+            "Auto-reload disabled: incompatible with Python %d.%d on Windows. "
+            "Restart the backend manually after code changes.",
+            sys.version_info.major, sys.version_info.minor,
+        )
+
     uvicorn.run(
         "main:app",
         host="0.0.0.0",
         port=port,
-        reload=True,
+        reload=reload_enabled,
         log_level="info",
+        # loop="none" keeps uvicorn from resetting the WindowsProactorEventLoopPolicy
+        # set at the top of this file, which Playwright requires to spawn Chromium
+        # on Windows (see issue #3).
+        loop="none",
     )


### PR DESCRIPTION
Re-opened replacement for #6 (auto-closed by a history-rewrite force-push that purged a committed API key from all history).

## Summary
Resolves **#2**, **#3**, **#4**.

### #2 — Security
- **Proxy opt-out honored.** `conversation_pipeline.py` and `/api/project-name` in `main.py` read `CLAUDE_PROXY_BASE_URL` **only when `USE_CLAUDE_PROXY=true`**, so a direct `ANTHROPIC_API_KEY` is never silently routed to a third-party proxy.
- **No hardcoded toggle.** `code_gen_config.py` reads `USE_CLAUDE_PROXY` from the env instead of hardcoding `True`.
- **Committed secret purged.** `backend/test_yinli_api.py` (hardcoded API key) was removed and **scrubbed from all git history** via `filter-branch` + force-push.
- **Proxy documented** in both `.env.example` files; default is direct-to-`api.anthropic.com`.

### #3 — Windows Playwright `NotImplementedError`
`uvicorn.run(..., loop="none")` so uvicorn doesn't reset the `WindowsProactorEventLoopPolicy` needed to spawn Chromium.

### #4 — Windows + Python 3.13 uvicorn reload crash
Auto-reload disabled only on Windows + Python ≥ 3.13 (ProactorEventLoop IOCP `WinError 87` regression).

## ⚠️ Follow-up
The leaked key existed in public history and may already be cached/forked — it **must be revoked/rotated** at the proxy provider. History rewrite is not a substitute for rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)